### PR TITLE
A new option which allows to disable automatic sidebars appear after window gets wide again.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,8 @@ export default class HideSidebarsOnWindowResizePlugin extends Plugin {
 		}
 		else if (width > this.settings.leftMinWidth &&
 			width > this.previousWidth &&
-			this.app.workspace.leftSplit.collapsed) {
+			this.app.workspace.leftSplit.collapsed &&
+			this.settings.showSidebarsBack) {
 			this.app.workspace.leftSplit.expand();
 		}
 
@@ -40,11 +41,12 @@ export default class HideSidebarsOnWindowResizePlugin extends Plugin {
 		}
 		else if (width > this.settings.rightMinWidth &&
 			width > this.previousWidth &&
-			this.app.workspace.rightSplit.collapsed) {
+			this.app.workspace.rightSplit.collapsed &&
+			this.settings.showSidebarsBack) {
 			this.app.workspace.rightSplit.expand();
 		}
 
-		this.previousWidth = width;
+		this.previousWidth = width; 
 	}
 
 	async loadSettings() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,14 +1,16 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting, ToggleComponent } from "obsidian";
 import HideSidebarsOnWindowResizePlugin from "./main";
 
 export interface HideSidebarsOnWindowResizeSettings {
 	leftMinWidth: number;
 	rightMinWidth: number;
+	showSidebarsBack: boolean;
 }
 
 export const DEFAULT_SETTINGS: HideSidebarsOnWindowResizeSettings = {
 	leftMinWidth: 1400,
 	rightMinWidth: 1100,
+	showSidebarsBack: true,
 };
 
 export class SettingsTab extends PluginSettingTab {
@@ -69,5 +71,17 @@ export class SettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(this.containerEl)
+			.setName("Show sidebars back when window becomes wide again")
+			.setDesc("Sidebars remain hidden if option is disabled")
+			.addToggle((component: ToggleComponent) => {
+				component.setValue(this.plugin.settings.showSidebarsBack);
+				component.onChange((value: boolean) => {
+					this.plugin.settings.showSidebarsBack = value;
+					this.plugin.saveSettings();
+				});
+			});
+
 	}
 }


### PR DESCRIPTION
Hello, there!

I believe this can be useful for users when there is an option to disable the automatic appearance of sidebars after the window expands again. This is useful for me.

My idea: The original feature is good, but sometimes you expand the window just to see more content and you don't want the sidebars to eat up the width you're going to get.